### PR TITLE
Fix wrong type in frame_header len

### DIFF
--- a/include/proto.h
+++ b/include/proto.h
@@ -30,7 +30,7 @@ enum status {
 struct frame_header {
 	uint8_t id;
 	enum endpoints endpoint;
-	enum cmdlen len;
+	size_t len;
 };
 
 uint8_t genhdr(uint8_t id, uint8_t endpoint, uint8_t status, enum cmdlen len);


### PR DESCRIPTION
len in frame_header should be the parsed length in bytes not the cmdlen enum.

Closes #8 