### PR TITLE
Build library .a files on top level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@ CFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcmode
    -Wall -Werror=implicit-function-declaration \
    -I $(INCLUDE) -I . \
    -DNODEBUG
-ifneq ($(TKEY_SIGNER_APP_NO_TOUCH),)
-CFLAGS := $(CFLAGS) -DTKEY_SIGNER_APP_NO_TOUCH
-endif
 
 AS = clang
 ASFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcmodel=medany -mno-relax

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ clang -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 \
 clang -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 \
   -mcmodel=medany -static -ffast-math -fno-common -nostdlib \
   -T ../tkey-libs/app.lds \
-  -L ../tkey-libs/libcrt0/ -lcrt0 \
+  -L ../tkey-libs -lcrt0 \
   -I ../tkey-libs -o foo.elf foo.o
 
 ```

--- a/example-app/Makefile
+++ b/example-app/Makefile
@@ -11,7 +11,7 @@ CFLAGS = -g -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcm
 
 INCLUDE=$(LIBDIR)/include
 
-LDFLAGS=-T $(LIBDIR)/app.lds -L $(LIBDIR)/libcommon/ -lcommon -L $(LIBDIR)/libcrt0/ -lcrt0
+LDFLAGS=-T $(LIBDIR)/app.lds -L $(LIBDIR) -lcommon -lcrt0
 
 .PHONY: all
 all: blue.bin


### PR DESCRIPTION
Instead of having to do:

```
  -L $(LIBDIR)/libcrt0 -L $(LIBDIR)/libcommon/ -lcrt -lcommon
```

A user can now just do:

```
  -L $(LIBDIR)  -lcrt -lcommon
```

Please see https://github.com/tillitis/dev-tillitis/pull/23 for changes to the Dev Handbook.