### PR TITLE
Expose qemu_*() functions with QEMU_DEBUG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,12 @@ CC = clang
 
 INCLUDE=include
 
-# If you want libcommon's qemu_puts() et cetera to output something on our QEMU
-# debug port, remove -DNODEBUG below
 CFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcmodel=medany \
    -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf \
    -fno-builtin-putchar -nostdlib -mno-relax -flto \
    -Wall -Werror=implicit-function-declaration \
    -I $(INCLUDE) -I . \
-   -DNODEBUG
+   -D QEMU_DEBUG
 
 AS = clang
 ASFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcmodel=medany -mno-relax

--- a/README.md
+++ b/README.md
@@ -115,8 +115,12 @@ debug port on 0xfe00\_1000 (`TK1_MMIO_QEMU_DEBUG`). Anything written
 there will be printed as a character by qemu on the console.
 
 `qemu_putchar()`, `qemu_puts()`, `qemu_putinthex()`, `qemu_hexdump()`
-and friends (see `libcommon/lib.h` and `libcommon/qemu_debug.c`) use
-this debug port to print stuff.
+and friends (see `libcommon/qemu_debug.h`) use this debug port to print
+stuff.
 
-`libcommon` is compiled with no debug output by default. Rebuild
-`libcommon` without `-DNODEBUG` to get the debug output.
+If you want to use these, define QEMU_DEBUG when compiling your
+program, othwerwise all `qemu_*()` functions in your program are
+removed by the C pre-processor.
+
+`tkey-libs` own use of `qemu_*()` is limited to output from
+`assert()`.

--- a/example-app/Makefile
+++ b/example-app/Makefile
@@ -7,7 +7,7 @@ CFLAGS = -g -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcm
    -fno-builtin-putchar -nostdlib -mno-relax -flto \
    -Wall -Werror=implicit-function-declaration \
    -I $(LIBDIR)/include -I $(LIBDIR)  \
-   -DNODEBUG
+#   -D QEMU_DEBUG
 
 INCLUDE=$(LIBDIR)/include
 

--- a/example-app/blue.c
+++ b/example-app/blue.c
@@ -3,6 +3,7 @@
 
 #include <types.h>
 #include <tk1_mem.h>
+#include <qemu_debug.h>
 
 #define SLEEPTIME 100000
 #define LED_RED   (1 << TK1_MMIO_TK1_LED_R_BIT)
@@ -18,6 +19,11 @@ void sleep(uint32_t n)
 
 int main(void)
 {
+	qemu_puts("Hello, world!\n");
+	qemu_puts("Going to sleep between blinks: ");
+	qemu_putinthex(SLEEPTIME);
+	qemu_lf();
+
 	for (;;) {
 		*led = LED_RED;
 		sleep(SLEEPTIME);

--- a/include/qemu_debug.h
+++ b/include/qemu_debug.h
@@ -6,7 +6,7 @@
 
 #include <types.h>
 
-#ifdef NODEBUG
+#ifndef QEMU_DEBUG
 #define qemu_putchar(ch)
 #define qemu_lf()
 #define qemu_putinthex(n)

--- a/libcommon/proto.c
+++ b/libcommon/proto.c
@@ -66,8 +66,6 @@ void writebyte(uint8_t b)
 
 void write(uint8_t *buf, size_t nbytes)
 {
-	qemu_puts("Sending: \n");
-	qemu_hexdump(buf, nbytes);
 	for (int i = 0; i < nbytes; i++) {
 		writebyte(buf[i]);
 	}

--- a/libcommon/qemu_debug.c
+++ b/libcommon/qemu_debug.c
@@ -6,7 +6,6 @@
 #include <tk1_mem.h>
 #include <types.h>
 
-#ifndef NODEBUG
 // clang-format off
 static volatile uint8_t* const debugtx = (volatile uint8_t *)TK1_MMIO_QEMU_DEBUG;
 // clang-format on
@@ -103,4 +102,3 @@ void qemu_hexdump(uint8_t *buf, int len)
 
 	qemu_lf();
 }
-#endif


### PR DESCRIPTION
Instead of hiding the qemu_*() functions with NODEBUG and not even compile them into libcommon, we:

- Compile them into their own .o file and link them with libcommon.a always.

- Hide them in the qemu_debug.h as void macros when QEMU_DEBUG
  is not defined. Let the app's compilation define QEMU_DEBUG when it
  wants to use them and let the linker sort the rest.

See https://github.com/tillitis/dev-tillitis/pull/24 for Dev Handbook changes.

Closes #20 