### PR TITLE
Ci upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       image: ghcr.io/tillitis/tkey-builder:2
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # fetch-depth: 0
           persist-credentials: false
@@ -34,3 +34,17 @@ jobs:
 
       - name: check for SPDX tags
         run: ./tools/spdx-ensure
+
+      - name: Archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: tkey-libs
+          retention-days: 2
+          path: |
+            README-DIST.txt
+            app.lds
+            LICENSE
+            include/*
+            *.a
+            monocypher/*.h
+            monocypher/LICENSE

--- a/README-DIST.txt
+++ b/README-DIST.txt
@@ -1,0 +1,40 @@
+tkey-libs binary distribution
+
+This is the binary distribution of:
+
+  https://github.com/tillitis/tkey-libs
+
+Which is an SDK for developing device apps for the Tillitis TKey in C.
+Please see the TKey Developer Handbook for more:
+
+  https://dev.tillitis.se/
+
+and the company web site:
+
+  https://tillitis.se/
+
+You should be able to use this distribution directly in device apps
+simply by pointing LIBDIR to where you unpacked this archive:
+
+  make LIBDIR=~/Download/tkey-libs
+
+Copyright Tillitis AB.
+
+These programs are free software: you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation, version 2 only.
+
+These programs are distributed in the hope that they will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see:
+
+  https://www.gnu.org/licenses
+
+See LICENSE for the full GPLv2-only license text.
+
+Note that Monocypher is Copyright Loup Vaillant and released under CC0
+1.0 Universal, see monocypher/LICENSE.

--- a/tools/spdx-ensure
+++ b/tools/spdx-ensure
@@ -20,6 +20,7 @@ missingok_files=(
 LICENSE
 Makefile
 README.md
+README-DIST.txt
 RELEASE.md
 example-app/Makefile
 monocypher/LICENSE


### PR DESCRIPTION
- Updated checkout to v4. The nodejs used for v3 is being deprecated.
- Included an archive step. It includes all files needed for using `make LIBDIR=/the_downloaded_folder`. The idea is that we can use this for every release, and not have to do it manually. 