### PR TITLE
proto: use enum endpoints in genhdr

### DIFF
--- a/include/tkey/proto.h
+++ b/include/tkey/proto.h
@@ -34,7 +34,7 @@ struct frame_header {
 	size_t len;
 };
 
-uint8_t genhdr(uint8_t id, uint8_t endpoint, uint8_t status, enum cmdlen len);
+uint8_t genhdr(uint8_t id, enum endpoints endpoint, uint8_t status, enum cmdlen len);
 int parseframe(uint8_t b, struct frame_header *hdr);
 void writebyte(uint8_t b);
 void write(const uint8_t *buf, size_t nbytes);

--- a/libcommon/proto.c
+++ b/libcommon/proto.c
@@ -14,7 +14,7 @@ static volatile uint32_t* const can_tx = (volatile uint32_t *)TK1_MMIO_UART_TX_S
 static volatile uint32_t* const tx =     (volatile uint32_t *)TK1_MMIO_UART_TX_DATA;
 // clang-format on
 
-uint8_t genhdr(uint8_t id, uint8_t endpoint, uint8_t status, enum cmdlen len)
+uint8_t genhdr(uint8_t id, enum endpoints endpoint, uint8_t status, enum cmdlen len)
 {
 	return (id << 5) | (endpoint << 3) | (status << 2) | len;
 }


### PR DESCRIPTION
Use `enum endpoints` instead of `uint8_t` for parameter `endpoint`.

I'm not sure if this was accidental or deliberate, but in my (limited) knowledge there is no downside to using the enum for the parameter.