### PR TITLE
blake2s: use local variable for blake2s_ctx, move blake2s_ctx type

### DIFF
--- a/include/tkey/blake2s.h
+++ b/include/tkey/blake2s.h
@@ -7,16 +7,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// blake2s state context
-typedef struct {
-	uint8_t b[64]; // input buffer
-	uint32_t h[8]; // chained state
-	uint32_t t[2]; // total number of bytes
-	size_t c;      // pointer for b[]
-	size_t outlen; // digest size
-} blake2s_ctx;
-
 int blake2s(void *out, unsigned long outlen, const void *key,
-	    unsigned long keylen, const void *in, unsigned long inlen,
-	    blake2s_ctx *ctx);
+	    unsigned long keylen, const void *in, unsigned long inlen);
+
 #endif

--- a/libcommon/blake2s.c
+++ b/libcommon/blake2s.c
@@ -5,16 +5,24 @@
 #include <tkey/blake2s.h>
 #include <tkey/tk1_mem.h>
 
+// blake2s state context
+typedef struct {
+	uint8_t b[64]; // input buffer
+	uint32_t h[8]; // chained state
+	uint32_t t[2]; // total number of bytes
+	size_t c;      // pointer for b[]
+	size_t outlen; // digest size
+} blake2s_ctx;
+
 typedef int (*fw_blake2s_p)(void *out, unsigned long outlen, const void *key,
 			    unsigned long keylen, const void *in,
 			    unsigned long inlen, blake2s_ctx *ctx);
 
 int blake2s(void *out, unsigned long outlen, const void *key,
-	    unsigned long keylen, const void *in, unsigned long inlen,
-	    blake2s_ctx *ctx)
+	    unsigned long keylen, const void *in, unsigned long inlen)
 {
 	fw_blake2s_p const fw_blake2s =
 	    (fw_blake2s_p) * (volatile uint32_t *)TK1_MMIO_TK1_BLAKE2S;
-
-	return fw_blake2s(out, outlen, key, keylen, in, inlen, ctx);
+	blake2s_ctx ctx;
+	return fw_blake2s(out, outlen, key, keylen, in, inlen, &ctx);
 }


### PR DESCRIPTION
https://github.com/tillitis/tkey-libs/issues/38 here's a rough change for simplifying the call to `blake2s`. (I only checked that it compiles.) See the issue for further discussion on this probable simplification.