### PR TITLE
Fix alignment for qemu_hexdump

### DIFF
--- a/libcommon/qemu_debug.c
+++ b/libcommon/qemu_debug.c
@@ -95,7 +95,7 @@ void qemu_hexdump(const uint8_t *buf, int len)
 			(void)qemu_putchar(' ');
 		}
 
-		if (i != 1 && i % 16 == 1) {
+		if ((i + 1) % 16 == 0) {
 			qemu_lf();
 		}
 	}


### PR DESCRIPTION
## Description

When using the qemu_hexdump() function it would look like this:

```
0001 0203 0405 0607 0809 0a0b 0c0d 0e0f 1011
1213 1415 1617 1819 1a1b 1c1d 1e1f 2021
2223 2425 2627 2829 2a2b 2c2d 2e2f 3031
3233 3435 3637 3839 3a3b 3c3d 3e3f 4041f
...
e2e3 e4e5 e6e7 e8e9 eaeb eced eeef f0f1
f2f3 f4f5 f6f7 f8f9 fafb fcfd feff
```
where we can see that the last 2 bytes for each row is printed on the wrong row.

With this fix it would instead look like
```
0001 0203 0405 0607 0809 0a0b 0c0d 0e0f
1011 1213 1415 1617 1819 1a1b 1c1d 1e1f
2021 2223 2425 2627 2829 2a2b 2c2d 2e2f
3031 3233 3435 3637 3839 3a3b 3c3d 3e3f
...
e0e1 e2e3 e4e5 e6e7 e8e9 eaeb eced eeef
f0f1 f2f3 f4f5 f6f7 f8f9 fafb fcfd feff
```


Fixes # (issues)

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
