### PR TITLE
Synchronize tk1_mem.h with upstream

### DIFF
--- a/include/tkey/led.h
+++ b/include/tkey/led.h
@@ -15,7 +15,7 @@
 #define LED_WHITE (LED_RED | LED_GREEN | LED_BLUE)
 // clang-format on
 
-uint32_t led_get();
+uint32_t led_get(void);
 void led_set(uint32_t ledvalue);
 void led_flash_forever(uint32_t ledvalue);
 #endif

--- a/include/tkey/tk1_mem.h
+++ b/include/tkey/tk1_mem.h
@@ -4,6 +4,9 @@
  * SPDX-FileCopyrightText: 2022 Tillitis AB <tillitis.se>
  * SPDX-License-Identifier: BSD-2-Clause
  *
+ * Note that this file is also in tillitis-key1 and qemu
+ * (GPL-2.0-or-later). Needs to stay in sync and have a compatible
+ * license.
  */
 
 // clang-format off
@@ -12,15 +15,17 @@
 #define TKEY_TK1_MEM_H
 
 /*
-
   The canonical location of this file is in:
 
-  https://github.com/tillitis/tillitis-key1
+    https://github.com/tillitis/tkey-libs
 
-  /hw/application_fpga/fw/tk1_mem.h
+  Under:
 
-  The contents are derived from the Verilog code. For use by QEMU model,
-  firmware, and apps.
+    include/tkey/tk1_mem.h
+
+  The contents are mostly derived from the Verilog code in
+
+    https://github.com/tillitis/tillitis-key1
 
   Memory map
 
@@ -31,7 +36,7 @@
   ROM		0b00	30 bit address
   RAM		0b01	30 bit address
   Reserved	0b10
-  MMIO		0b11	6 bits for core select, 24 bits rest
+  Cores		0b11	6 bits for core select, 24 bits rest
 
   Address Prefix, the first 8 bits in a 32-bit address:
 
@@ -39,18 +44,19 @@
   --------------------
   ROM		0x00
   RAM		0x40
-  MMIO		0xc0
-  MMIO TRNG	0xc0
-  MMIO TIMER	0xc1
-  MMIO UDS	0xc2
-  MMIO UART	0xc3
-  MMIO TOUCH	0xc4
-  MMIO FW_RAM	0xd0
-  MMIO QEMU	0xfe   Not used in real hardware
-  MMIO TK1	0xff
+  TRNG		0xc0
+  TIMER		0xc1
+  UDS		0xc2
+  UART		0xc3
+  TOUCH		0xc4
+  FW_RAM	0xd0
+  QEMU		0xfe   Not used in real hardware
+  TK1		0xff
  */
 
 #define TK1_ROM_BASE 0x00000000
+#define TK1_ROM_SIZE 0x2000
+
 #define TK1_RAM_BASE 0x40000000
 #define TK1_RAM_SIZE 0x20000
 
@@ -60,8 +66,8 @@
 #define TK1_APP_MAX_SIZE 0x20000
 
 #define TK1_MMIO_FW_RAM_BASE 0xd0000000
-// FW_RAM is 2048 bytes
-#define TK1_MMIO_FW_RAM_SIZE 0x800
+// FW_RAM is 4096 bytes
+#define TK1_MMIO_FW_RAM_SIZE 0x1000
 
 #define TK1_MMIO_TRNG_BASE 0xc0000000
 #define TK1_MMIO_TRNG_STATUS 0xc0000024
@@ -79,8 +85,8 @@
 #define TK1_MMIO_TIMER_TIMER 0xc100002c
 
 #define TK1_MMIO_UDS_BASE 0xc2000000
-#define TK1_MMIO_UDS_FIRST 0xc2000040
-#define TK1_MMIO_UDS_LAST 0xc200005c
+#define TK1_MMIO_UDS_FIRST 0xc2000000
+#define TK1_MMIO_UDS_LAST 0xc200001c
 
 #define TK1_MMIO_UART_BASE 0xc3000000
 #define TK1_MMIO_UART_RX_STATUS 0xc3000080
@@ -103,10 +109,6 @@
 #define TK1_MMIO_TK1_NAME1 0xff000004
 #define TK1_MMIO_TK1_VERSION 0xff000008
 
-// Deprecated - use _SYSTEM_MODE_CTRL instead
-#define TK1_MMIO_TK1_SWITCH_APP 0xff000020
-#define TK1_MMIO_TK1_SYSTEM_MODE_CTRL 0xff000020
-
 #define TK1_MMIO_TK1_LED 0xff000024
 #define TK1_MMIO_TK1_LED_R_BIT 2
 #define TK1_MMIO_TK1_LED_G_BIT 1
@@ -120,8 +122,6 @@
 
 #define TK1_MMIO_TK1_APP_ADDR 0xff000030
 #define TK1_MMIO_TK1_APP_SIZE 0xff000034
-
-#define TK1_MMIO_TK1_BLAKE2S 0xff000040
 
 #define TK1_MMIO_TK1_CDI_FIRST 0xff000080
 #define TK1_MMIO_TK1_CDI_LAST 0xff00009c

--- a/libcommon/blake2s.c
+++ b/libcommon/blake2s.c
@@ -5,16 +5,10 @@
 #include <tkey/blake2s.h>
 #include <tkey/tk1_mem.h>
 
-typedef int (*fw_blake2s_p)(void *out, unsigned long outlen, const void *key,
-			    unsigned long keylen, const void *in,
-			    unsigned long inlen, blake2s_ctx *ctx);
-
 int blake2s(void *out, unsigned long outlen, const void *key,
 	    unsigned long keylen, const void *in, unsigned long inlen,
 	    blake2s_ctx *ctx)
 {
-	fw_blake2s_p const fw_blake2s =
-	    (fw_blake2s_p) * (volatile uint32_t *)TK1_MMIO_TK1_BLAKE2S;
-
-	return fw_blake2s(out, outlen, key, keylen, in, inlen, ctx);
+	// Not implemented.
+	return -1;
 }


### PR DESCRIPTION
## Description

tk1_mem.h usually lives in tillitis-key1 and has been updated there. Synchronize with tkey-libs. From now tk1_mem.h will now live in tkey-libs and tkey-libs will be used in tillitis-key1.

We keep the BSD2 copyright that was in tkey-libs which is compatible with GPLv2.

- Increase ROM_SIZE.
- Increase FW_RAM_SIZE.
- Correct UDS address.
- Remove SWITCH_APP, SYSTEM_MODE_CTRL, and BLAKE2S.

We also mark `blake2s()` as non-implemented for now, pending inclusion of the blake2s library in tkey-libs.

## Type of change

- [x] Feature (non breaking change which adds functionality)
- [x] Breaking Change (a change which would cause existing functionality to not work as expected)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
