### PR TITLE
Change assert() behaviour when no debug printing is used

### DIFF
--- a/include/tkey/assert.h
+++ b/include/tkey/assert.h
@@ -20,13 +20,10 @@
 
 #else
 
-#define assert(expr)                                                           \
-	((expr) ? (void)(0)                                                    \
-		: assert_fail(IO_NONE, #expr, __FILE__, __LINE__, __func__))
-
+#define assert(expr) ((expr) ? (void)(0) : assert_halt())
 #endif
 
 void assert_fail(enum ioend dest, const char *assertion, const char *file,
 		 unsigned int line, const char *function);
-
+void assert_halt(void);
 #endif

--- a/libcommon/assert.c
+++ b/libcommon/assert.c
@@ -24,3 +24,12 @@ void assert_fail(enum ioend dest, const char *assertion, const char *file,
 	// Not reached
 	__builtin_unreachable();
 }
+
+void assert_halt(void)
+{
+	// Force illegal instruction to halt CPU
+	asm volatile("unimp");
+
+	// Not reached
+	__builtin_unreachable();
+}


### PR DESCRIPTION
## Description

When neither QEMU_DEBUG nor TKEY_DEBUG is set we no don't need to keep debug data such as the file (__FILE__) and line numbers (__LINE__) et cetera available. In such a case we call the assert_halt() function instead of assert_fail() and just halt the CPU.

This will also make us produce reproducible binaries again, hopefully.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
