### PR TITLE
Rename USB endpoints and add new internal for CH552

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,8 +9,8 @@ NOTE WELL! Rewritten I/O functions with new semantics!
 The Castor TKey hardware supports more USB endpoints:
 
 - CDC - the same thing as older versions.
-- HID security token, for FIDO-like apps.
-- CTRL, a HID debug port.
+- FIDO security token, for FIDO-like apps.
+- DEBUG, a HID debug port.
 
 The communication is still over a single UART. To differ between the
 endpoints we use an internal USB Mode Protocol between programs
@@ -18,7 +18,7 @@ running on the PicoRV32 and the CH552 USB Controller.
 
 The I/O functions has changed accordingly. Please use:
 
-- `readselect()` with appropriate bitmask (e.g. `IO_CDC|IO_HID`) to
+- `readselect()` with appropriate bitmask (e.g. `IO_CDC|IO_FIDO`) to
   see if there's anything to read in the endpoints you are interested
   in. Data from endpoints not mentioned in the bitmask will be
   discarded.
@@ -48,7 +48,7 @@ The optionally built debug prints have changed. You now use
 
 You define the debug output endpoint when you compile your program by
 including `debug.h` and defining `QEMU_DEBUG` for the qemu debug port
-or `TKEY_DEBUG` for output on the CTRL HID endpoint. If you don't
+or `TKEY_DEBUG` for output on the DEBUG HID endpoint. If you don't
 define either, they won't appear in your code.
 
 Similiarly, `assert()` now also follows `QEMU_DEBUG` or `TKEY_DEBUG`,

--- a/include/tkey/assert.h
+++ b/include/tkey/assert.h
@@ -14,9 +14,8 @@
 #elif defined(TKEY_DEBUG)
 
 #define assert(expr)                                                           \
-	((expr)                                                                \
-	     ? (void)(0)                                                       \
-	     : assert_fail(IO_TKEYCTRL, #expr, __FILE__, __LINE__, __func__))
+	((expr) ? (void)(0)                                                    \
+		: assert_fail(IO_DEBUG, #expr, __FILE__, __LINE__, __func__))
 
 #else
 

--- a/include/tkey/debug.h
+++ b/include/tkey/debug.h
@@ -18,12 +18,12 @@
 
 #elif defined(TKEY_DEBUG)
 
-#define debug_putchar(ch) putchar(IO_TKEYCTRL, ch)
-#define debug_lf() putchar(IO_TKEYCTRL, '\n')
-#define debug_putinthex(ch) putinthex(IO_TKEYCTRL, ch)
-#define debug_puts(s) puts(IO_TKEYCTRL, s)
-#define debug_puthex(ch) puthex(IO_TKEYCTRL, ch)
-#define debug_hexdump(buf, len) hexdump(IO_TKEYCTRL, buf, len)
+#define debug_putchar(ch) putchar(IO_DEBUG, ch)
+#define debug_lf() putchar(IO_DEBUG, '\n')
+#define debug_putinthex(ch) putinthex(IO_DEBUG, ch)
+#define debug_puts(s) puts(IO_DEBUG, s)
+#define debug_puthex(ch) puthex(IO_DEBUG, ch)
+#define debug_hexdump(buf, len) hexdump(IO_DEBUG, buf, len)
 
 #else
 

--- a/include/tkey/io.h
+++ b/include/tkey/io.h
@@ -10,15 +10,16 @@
 // I/O endpoints. Keep it as bits possible to use in a bitmask in
 // readselect().
 //
-// Note that the the TKEYCTRL, CDC, and HID should be kept the same on
+// Note that the DEBUG, CDC, and FIDO should be kept the same on
 // the CH552 side.
 enum ioend {
-	IO_NONE = 0x00,	    // No endpoint
-	IO_UART = 0x01,	    // Only destination, raw UART access
-	IO_QEMU = 0x10,	    // Only destination, QEMU debug port
-	IO_TKEYCTRL = 0x20, // HID debug port
-	IO_CDC = 0x40,	    // CDC "serial port"
-	IO_HID = 0x80,	    // HID security token
+	IO_NONE = 0x00,	 // No endpoint
+	IO_UART = 0x01,	 // Only destination, raw UART access
+	IO_QEMU = 0x02,	 // Only destination, QEMU debug port
+	IO_CH552 = 0x10, // Internal CH552 control port
+	IO_DEBUG = 0x20, // HID debug port
+	IO_CDC = 0x40,	 // CDC "serial port"
+	IO_FIDO = 0x80,	 // FIDO security token port
 };
 
 void write(enum ioend dest, const uint8_t *buf, size_t nbytes);

--- a/libcommon/io.c
+++ b/libcommon/io.c
@@ -80,9 +80,9 @@ static void write_with_header(enum ioend dest, const uint8_t *buf,
 //
 // - IO_CDC: Through the UART for the CDC endpoint, with header.
 //
-// - IO_HID: Through the UART for the HID endpoint, with header.
+// - IO_FIDO: Through the UART for the FIDO endpoint, with header.
 //
-// - IO_TKEYCTRL: Through the UART for the debug HID endpoint, with
+// - IO_DEBUG: Through the UART for the DEBUG HID endpoint, with
 //   header.
 void write(enum ioend dest, const uint8_t *buf, size_t nbytes)
 {
@@ -194,18 +194,18 @@ static int discard(size_t nbytes)
 //
 // Use like this:
 //
-//   readselect(IO_CDC|IO_HID, &endpoint, &len)
+//   readselect(IO_CDC|IO_FIDO, &endpoint, &len)
 //
-// to wait for some data from either the CDC or the HID endpoint.
+// to wait for some data from either the CDC or the FIDO endpoint.
 //
 // NOTE WELL: You need to call readselect() first, before doing any
 // calls to read().
 //
 // Only endpoints available for read are:
 //
-// - IO_TKEYCTRL
+// - IO_DEBUG
 // - IO_CDC
-// - IO_HID
+// - IO_FIDO
 //
 // If you need blocking low-level UART reads, use uart_read() instead.
 //
@@ -215,7 +215,7 @@ static int discard(size_t nbytes)
 // Returns non-zero on error.
 int readselect(int bitmask, enum ioend *endpoint, uint8_t *len)
 {
-	if (bitmask & IO_UART || bitmask & IO_QEMU) {
+	if ((bitmask & IO_UART) || (bitmask & IO_QEMU)) {
 		// Not possible to use readselect() on these
 		// endpoints.
 		return -1;


### PR DESCRIPTION
## Description

- Change name of IO_TKEYCTRL to IO_DEBUG
- Change name of IO_HID to IO_FIDO
- Add internal FPGA<->CH552 communication (IO_CH552)
- Reorder IO_QEMU in the ioend enum to better match the framing dependant endpoints.

Part of the [#312](https://github.com/tillitis/tillitis-key1/issues/312)

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
