### PR TITLE
Add CCID (Smart Card) support and sort frame header numbers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,6 +32,7 @@ The Castor TKey hardware supports more USB endpoints:
 
 - CDC - the same thing as older versions.
 - FIDO security token, for FIDO-like apps.
+- CCID, smart card interface.
 - DEBUG, a HID debug port.
 
 The communication is still over a single UART. To differ between the

--- a/include/tkey/io.h
+++ b/include/tkey/io.h
@@ -10,20 +10,22 @@
 // I/O endpoints. Keep it as bits possible to use in a bitmask in
 // readselect().
 //
-// Note that the DEBUG, CDC, and FIDO should be kept the same on
-// the CH552 side.
+// Note that the values for IO_CH552, IO_CDC, IO_FIDO, IO_CCID and IO_DEBUG
+// should be kept the same in the code for the CH552 side.
 enum ioend {
 	IO_NONE = 0x00,	 // No endpoint
 	IO_UART = 0x01,	 // Only destination, raw UART access
 	IO_QEMU = 0x02,	 // Only destination, QEMU debug port
-	IO_CH552 = 0x10, // Internal CH552 control port
-	IO_DEBUG = 0x20, // HID debug port
-	IO_CDC = 0x40,	 // CDC "serial port"
-	IO_FIDO = 0x80,	 // FIDO security token port
+	IO_CH552 = 0x04, // Internal CH552 control port
+	IO_CDC = 0x08,	 // CDC "serial" port
+	IO_FIDO = 0x10,	 // FIDO security token port
+	IO_CCID = 0x20,	 // CCID "smart card" port
+	IO_DEBUG = 0x40, // Debug port over USB HID
 };
 
 enum ch552cmd {
 	SET_ENDPOINTS = 0x01, // Config USB endpoints on the CH552
+	CH552_CMD_MAX,
 };
 
 void write(enum ioend dest, const uint8_t *buf, size_t nbytes);

--- a/libcommon/io.c
+++ b/libcommon/io.c
@@ -74,15 +74,20 @@ static void write_with_header(enum ioend dest, const uint8_t *buf,
 // write blockingly writes nbytes bytes of data from buf to dest which
 // is either:
 //
+// - IO_UART: Low-level UART access, no USB Mode Header added.
+//
 // - IO_QEMU: QEMU debug port
 //
-// - IO_UART: Low-level UART access, no USB Mode Header added.
+// - IO_CH552: Internal communication between the FPGA and the
+//   CH552, with header.
 //
 // - IO_CDC: Through the UART for the CDC endpoint, with header.
 //
 // - IO_FIDO: Through the UART for the FIDO endpoint, with header.
 //
-// - IO_DEBUG: Through the UART for the DEBUG HID endpoint, with
+// - IO_CCID: Through the UART for the CCID endpoint, with header.
+//
+// - IO_DEBUG: Through the UART for the DEBUG endpoint (USB HID), with
 //   header.
 void write(enum ioend dest, const uint8_t *buf, size_t nbytes)
 {
@@ -203,9 +208,11 @@ static int discard(size_t nbytes)
 //
 // Only endpoints available for read are:
 //
-// - IO_DEBUG
+// - IO_CH552
 // - IO_CDC
 // - IO_FIDO
+// - IO_CCID
+// - IO_DEBUG
 //
 // If you need blocking low-level UART reads, use uart_read() instead.
 //
@@ -352,7 +359,8 @@ void hexdump(enum ioend dest, void *buf, int len)
 // Configure USB endpoints that should be enabled/disabled
 //
 // Allowed options are:
-//   - IO_FIDO
+//   - IO_FIDO (can't be used used together with IO_CCID)
+//   - IO_CCID (can't be used used together with IO_FIDO)
 //   - IO_DEBUG
 //
 // The following are always enabled:


### PR DESCRIPTION
## Description

- Add frame number for CCID (Smart Card) support.
- Update documentation to reflect CCID support.
- Misc. documentation reorganization.

Fixes [tillitis-key1/#334](https://github.com/tillitis/tillitis-key1/issues/334)

## Type of change

- [ ] Bugfix (non breaking change which resolve an issue)
- [X] Feature (non breaking change which adds functionality)
- [x] Breaking Change (a change which would cause existing functionality to not work as expected)
- [X] Documentation (a change to documentation)

## Submission checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my changes
- [X] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
