### PR TITLE
Update sys_write and sys_preload_store documentation to match implementation

### DIFF
--- a/libsyscall/sys_wrapper.c
+++ b/libsyscall/sys_wrapper.c
@@ -47,8 +47,8 @@ int sys_dealloc(void)
 // Write data in `buf` to the app's flash area at byte `offset` within
 // the area.
 //
-// At most 4096 bytes can be written at once and `offset` must be a
-// multiple of 4096 bytes.
+// Up to storage area size bytes can be written at once and `offset` must be a
+// multiple of 256 bytes.
 //
 // Returns 0 on success.
 int sys_write(uint32_t offset, void *buf, size_t len)
@@ -97,8 +97,8 @@ int sys_preload_delete(void)
 // `sys_preload_store` many times as you receive the binary from the
 // client. Returns 0 on success.
 //
-// At most 4096 bytes can be written at once and `offset` must be a
-// multiple of 4096 bytes.
+// Up to preloaded app area size bytes can be written at once and `offset` must
+// be a multiple of 256 bytes.
 //
 // Only available for the verified management app.
 //


### PR DESCRIPTION
## Description

Update sys_write and sys_preload_store documentation to match implementation.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
