### PR TITLE
Make it clear that the arg to config_endpoints() is a bitmask

### DIFF
--- a/include/tkey/io.h
+++ b/include/tkey/io.h
@@ -37,6 +37,6 @@ void puthex(enum ioend dest, const uint8_t ch);
 void putinthex(enum ioend dest, const uint32_t n);
 void puts(enum ioend dest, const char *s);
 void hexdump(enum ioend dest, void *buf, int len);
-void config_endpoints(enum ioend endpoints);
+void config_endpoints(uint8_t endpoints);
 
 #endif

--- a/libcommon/io.c
+++ b/libcommon/io.c
@@ -367,11 +367,11 @@ void hexdump(enum ioend dest, void *buf, int len)
 //   - IO_CDC
 //   - IO_CH552
 //
-// Use like this:
+// Use like this in the bitmask:
 //
 //   config_endpoints(IO_FIDO|IO_DEBUG)
 //
-void config_endpoints(enum ioend endpoints)
+void config_endpoints(uint8_t endpoints)
 {
 	uint8_t cmdbuf[2] = {0};
 


### PR DESCRIPTION
## Description

The argument endpoints to `config_endpoints()` is a bitmask made up of combining bits defined in `enum ioend`, not a single `enum ioend` item itself.

Make it uint8_t, since it has to fit in a byte in the USB Mode Protocol.

Since an enum is just another `int`, this has gone undetected.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
