### PR TITLE
Move APP stack to beginning of RAM

### DIFF
--- a/app.lds
+++ b/app.lds
@@ -6,6 +6,9 @@
 OUTPUT_ARCH( "riscv" )
 ENTRY(_start)
 
+/* Define stack size */
+STACK_SIZE = 16K;
+
 MEMORY
 {
 	RAM (rwx)   : ORIGIN = 0x40000000, LENGTH = 0x20000 /* 128 KB */
@@ -18,9 +21,20 @@ SECTIONS
 		*(.text.init)
 	} >RAM
 
+	.stack (NOLOAD) :
+	{
+		. = ALIGN(16);
+		_sstack = .;
+		. += STACK_SIZE;
+		. = ALIGN(16);
+		_estack = .;
+		_sidata = _estack;
+	} >RAM
+
 	.text :
 	{
 		. = ALIGN(4);
+		_stext = .;
 		*(.text)           /* .text sections (code) */
 		*(.text*)          /* .text* sections (code) */
 		*(.rodata)         /* .rodata sections (constants, strings, etc.) */
@@ -60,5 +74,4 @@ SECTIONS
 		_ebss = .;
 	} >RAM
 
-	/* libcrt0/crt0.S inits stack to start just below end of RAM */
 }

--- a/libcrt0/crt0.S
+++ b/libcrt0/crt0.S
@@ -36,8 +36,8 @@ _start:
 	li x30,0
 	li x31,0
 
-	/* init stack below 0x40020000 (TK1_RAM_BASE+TK1_RAM_SIZE) */
-	li sp, 0x4001fff0
+	/* init stack */
+	la sp, _estack
 
 	/* zero-init bss section */
 	la a0, _sbss


### PR DESCRIPTION
## Description

This change will make it more visible if the stack is too small (writing outside of RAM will blink red forever) for an app and also make sure no .bss or .data is corrupted.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
 