### PR TITLE
Bug fix: read() would read data after the current endpoint data was exhausted.

### DIFF
--- a/libcommon/io.c
+++ b/libcommon/io.c
@@ -153,7 +153,7 @@ int read(enum ioend src, uint8_t *buf, size_t bufsize, size_t nbytes)
 
 	int n = 0;
 
-	for (n = 0; n < nbytes; n++) {
+	for (n = 0; n < nbytes && cur_endpoint.len > 0; n++) {
 		buf[n] = readbyte();
 		cur_endpoint.len--;
 	}


### PR DESCRIPTION
## Description

If we don't have anything else to read in the current endpoint, return early.

Fix a bug where read() would call readbyte() after the current endpoint data has been exhausted.

Thanks to Niels Möller <nisse@glasklarteknik.se> for reporting.

Related to #76 

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
