### PR TITLE
Add const declaration to hexdump input pointer

### DIFF
--- a/include/tkey/io.h
+++ b/include/tkey/io.h
@@ -36,7 +36,7 @@ void putchar(enum ioend dest, const uint8_t ch);
 void puthex(enum ioend dest, const uint8_t ch);
 void putinthex(enum ioend dest, const uint32_t n);
 void puts(enum ioend dest, const char *s);
-void hexdump(enum ioend dest, void *buf, int len);
+void hexdump(enum ioend dest, const void *buf, int len);
 void config_endpoints(uint8_t endpoints);
 
 #endif

--- a/libcommon/io.c
+++ b/libcommon/io.c
@@ -322,11 +322,11 @@ void puts(enum ioend dest, const char *s)
 #define FULLROW (16 * 3)
 #define ROWBUFSIZE (FULLROW + 2)
 
-void hexdump(enum ioend dest, void *buf, int len)
+void hexdump(enum ioend dest, const void *buf, int len)
 {
 	uint8_t rowbuf[ROWBUFSIZE] = {0};
 	uint8_t hexbuf[2] = {0};
-	uint8_t *byte_buf = (uint8_t *)buf;
+	const uint8_t *byte_buf = buf;
 
 	int rowpos = 0;
 	for (int i = 0; i < len; i++) {


### PR DESCRIPTION
## Description

Avoids warnings when calling hexdump with a const pointer.

Fixes # (issues)

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
