### PR TITLE
build: Add more tests and files to clang-tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,11 @@ test: udiv
 udiv: libcommon/udiv.c
 	$(CC) -Wall -O -DSELF_TEST=1 libcommon/udiv.c -o udiv
 
+# TODO add dep on compile_commands.json when tkey-builder has bear
+# Not checking blake2s_test.c which uses stdio.h we don't have.
 .PHONY: check
 check:
-	$(CLANG_TIDY) -header-filter=.* -checks=cert-* libcommon/*.c -- $(CFLAGS)
+	$(CLANG_TIDY) -header-filter=.* -checks=clang-analyzer-*,cert-* blake2s/blake2s.c libcommon/*.c libsyscall/*.c monocypher/*.c -- $(CFLAGS)
 
 # C runtime library
 libcrt0.a: libcrt0/crt0.o


### PR DESCRIPTION
## Description

- Include the rest of the C code in clang-tidy's checks.
- Add clang-analyzer checks as well as the cert checks.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
