### PR TITLE
Support measured boot + verified boot

### DIFF
--- a/include/tkey/syscall.h
+++ b/include/tkey/syscall.h
@@ -8,7 +8,7 @@
 #define TKEY_SYSCALL_H
 
 #define RESET_DIGEST_SIZE 32
-#define RESET_DATA_SIZE 220
+#define RESET_DATA_SIZE 184
 
 // Needs to be held synchronized with syscall_num.h in firmware.
 enum reset_start {
@@ -21,9 +21,14 @@ enum reset_start {
 	START_CLIENT_VER = 6,
 };
 
+#define RESET_NEXT 0x01
+#define RESET_SEED 0x02
+
 struct reset {
 	enum reset_start type;
+	uint8_t mask;
 	uint8_t app_digest[RESET_DIGEST_SIZE];
+	uint8_t measured_id_seed[RESET_DIGEST_SIZE];
 	uint8_t next_app_data[RESET_DATA_SIZE];
 };
 


### PR DESCRIPTION
## Description

To be able to compute CDI in the alternative reset seed way:

- add `mask` and `measured_id_seed` to `struct reset`
- Reduce the `RESET_DATA_SIZE` to 184 bytes to still fit within the 256 limit of the `resetinfo` memory.

To use in a chain where you want to influence the next CDI, fill in `measured_id_seed` with something you want to be measured by firmare.

Related to https://github.com/tillitis/tillitis-key1/pull/376

## Type of change

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [x] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
