### PR TITLE
Add DEBUG build mode with linker relaxation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,19 @@ CFLAGS = \
 	-fno-builtin-putchar \
 	-ffast-math \
 	-fno-common \
-	-mno-relax \
 	-Wall \
 	-Werror=implicit-function-declaration
 
 ifdef QEMU
+CFLAGS += -mno-relax
 CFLAGS += -O0
 CFLAGS += -g3
+else ifdef DEBUG
+CFLAGS += -mrelax
+CFLAGS += -Oz
+CFLAGS += -flto
 else
+CFLAGS += -mno-relax
 CFLAGS += -Os
 CFLAGS += -flto
 endif
@@ -45,12 +50,12 @@ CFLAGS += -DLFS_NO_MALLOC
 # own device app* you just need to include tkey/debug.h and define
 # either of them. You don't need to recompile tkey-libs.
 #
-ifdef DEBUG
-CFLAGS += -DTKEY_DEBUG
-endif
 ifdef QEMU
 CFLAGS += -DQEMU_DEBUG
 CFLAGS += -DBUILD_FOR_QEMU
+endif
+ifdef DEBUG
+CFLAGS += -DTKEY_DEBUG
 endif
 
 # Set LFS_YES_TRACE below when compiling tkey-libs if you
@@ -65,7 +70,26 @@ ASFLAGS = \
 	-march=rv32iczmmul \
 	-mabi=ilp32 \
 	-mcmodel=medany \
-	-mno-relax
+
+ifdef QEMU
+ASFLAGS += -mno-relax
+ASFLAGS += -O0
+ASFLAGS += -g3
+else ifdef DEBUG
+ASFLAGS += -mrelax
+ASFLAGS += -Oz
+else
+ASFLAGS += -mno-relax
+ASFLAGS += -Os
+endif
+
+ifdef QEMU
+ASFLAGS += -DQEMU_DEBUG
+ASFLAGS += -DBUILD_FOR_QEMU
+endif
+ifdef DEBUG
+ASFLAGS += -DTKEY_DEBUG
+endif
 
 LDFLAGS = \
 	-static \
@@ -75,6 +99,12 @@ LDFLAGS = \
 	-lcommon \
 	-L libcrt0/ \
 	-lcrt0
+
+ifdef QEMU
+else ifdef DEBUG
+LDFLAGS += -Wl,--icf=safe
+else
+endif
 
 .PHONY: all
 all: libcrt0.a libcommon.a libsyscall.a libmonocypher.a liblfs.a libblake2s.a
@@ -115,12 +145,13 @@ libsyscall.a: $(SYSCALLOBJS)
 $(SYSCALLOBJS): include/tkey/syscall.h
 
 # Common C functions
-LIBOBJS = libcommon/assert.o libcommon/io.o libcommon/led.o libcommon/lib.o \
-	libcommon/memchr.o libcommon/memcmp.o libcommon/memcpy.o \
-	libcommon/memmove.o libcommon/memset.o libcommon/proto.o \
-	libcommon/strchr.o libcommon/strcmp.o libcommon/strcpy.o \
-	libcommon/strcspn.o libcommon/strlen.o libcommon/strncmp.o \
-	libcommon/strspn.o libcommon/timer.o libcommon/touch.o libcommon/udiv.o
+LIBOBJS = libcommon/ashldi3.o libcommon/assert.o libcommon/divsi3.o \
+	libcommon/io.o libcommon/led.o libcommon/lib.o libcommon/memchr.o \
+	libcommon/memcmp.o libcommon/memcpy.o libcommon/memmove.o \
+	libcommon/memset.o libcommon/proto.o libcommon/strchr.o \
+	libcommon/strcmp.o libcommon/strcpy.o libcommon/strcspn.o \
+	libcommon/strlen.o libcommon/strncmp.o libcommon/strspn.o \
+	libcommon/timer.o libcommon/touch.o libcommon/udiv.o
 libcommon.a: $(LIBOBJS)
 	-rm -f $@
 	$(AR) -qc $@ $(LIBOBJS)

--- a/libcommon/ashldi3.c
+++ b/libcommon/ashldi3.c
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Tillitis AB <tillitis.se>
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <stdint.h>
+
+uint64_t __ashldi3(uint64_t u, int b)
+{
+	if ((unsigned)b >= 64) {
+		return 0;
+	}
+
+	if (b == 0) {
+		return u;
+	}
+
+	uint32_t lo = (uint32_t)(u);
+	uint32_t hi = (uint32_t)(u >> 32);
+
+	if (b >= 32) {
+		hi = lo << (b - 32);
+		lo = 0;
+	} else {
+		hi = (hi << b) | (lo >> (32 - b));
+		lo = lo << b;
+	}
+
+	return ((uint64_t)hi << 32) | lo;
+}

--- a/libcommon/divsi3.c
+++ b/libcommon/divsi3.c
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Tillitis AB <tillitis.se>
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+static uint32_t udivmodsi4(uint32_t num, uint32_t den, uint32_t *rem_out)
+{
+	uint32_t quot = 0;
+	uint32_t rem = 0;
+
+	if (den == 0) {
+		// Undefined in C. Many runtimes just return 0.
+		if (rem_out) {
+			*rem_out = 0;
+		}
+		return 0;
+	}
+
+	for (int i = 31; i >= 0; i--) {
+		rem <<= 1;
+		rem |= (num >> i) & 1u;
+
+		if (rem >= den) {
+			rem -= den;
+			quot |= (1u << i);
+		}
+	}
+
+	if (rem_out) {
+		*rem_out = rem;
+	}
+
+	return quot;
+}
+
+int32_t __divsi3(int32_t a, int32_t b)
+{
+	// Division by zero
+	if (b == 0) {
+		assert(1 == 2);
+	}
+
+	if (a == (int32_t)0x80000000 && b == -1) {
+		return (int32_t)0x80000000;
+	}
+
+	uint32_t ua = (a < 0) ? -(uint32_t)a : (uint32_t)a;
+	uint32_t ub = (b < 0) ? -(uint32_t)b : (uint32_t)b;
+
+	uint32_t uq = udivmodsi4(ua, ub, NULL);
+
+	int neg = (a < 0) ^ (b < 0);
+
+	uint32_t uresult = neg ? -uq : uq;
+
+	return (int32_t)uresult;
+}

--- a/libcrt0/crt0.S
+++ b/libcrt0/crt0.S
@@ -36,6 +36,15 @@ _start:
 	li x30,0
 	li x31,0
 
+#ifdef TKEY_DEBUG
+	/* initialize global pointer, must be norelax or linker
+	will turn this into "mv gp, gp" */
+	.option push
+	.option norelax
+	la gp, __global_pointer$
+	.option pop
+#endif
+
 	/* init stack below end of ram (TK1_RAM_BASE+TK1_RAM_SIZE) */
 	la sp, _estack
 


### PR DESCRIPTION
## Description

Introduce a new DEBUG build variant alongside the existing QEMU and release configurations. DEBUG builds enable -mrelax (with -Oz and LTO) instead of the -mno-relax used everywhere else, and add -Wl,--icf=safe to the linker flags.

Since relaxation requires a properly initialized global pointer, gp is now set up in crt0.S under #ifdef TKEY_DEBUG, using .option norelax to prevent the linker from collapsing the "la gp, __global_pointer$" sequence into a no-op.

Enabling -mrelax also pulls in libgcc helpers that aren't normally needed (__ashldi3 for 64-bit left shift, __divsi3 for signed 32-bit division), so add local implementations of both to libcommon rather than depending on libgcc.

ASFLAGS now mirror CFLAGS with per-mode optimization levels and appropriate -D defines (BUILD_FOR_QEMU/QEMU_DEBUG for QEMU, TKEY_DEBUG for DEBUG builds).

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [x] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
